### PR TITLE
Update README and server response for GET and DELETE commands to clar…

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,22 +104,24 @@ Retrieves the value associated with a given key.
 ```
 Command: GET key\n
 Response: value\n
+Response: NOT_FOUND\n
 ```
 - The key must be a string
 - The command must end with a newline character
-- Server responds with the stored value followed by a newline
-- If the key doesn't exist, an empty line is returned
+- Server responds with the stored value followed by a newline if the key exists
+- Server responds with "NOT_FOUND" followed by a newline if the key doesn't exist
 
 #### DELETE
 Removes a key-value pair from the store.
 ```
 Command: DELETE key\n
+Response: OK\n
 Response: NOT_FOUND\n
 ```
 - The key must be a string
 - The command must end with a newline character
+- Server responds with "OK" followed by a newline if the key was found and successfully deleted
 - Server responds with "NOT_FOUND" followed by a newline if the key doesn't exist
-- On successful deletion, returns "OK" followed by a newline
 
 #### CLOSE
 Closes the current connection to the server.

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -244,7 +244,7 @@ void *handle_client(void *arg) {
         } else if (cmd_res.type == GET) {
             char *value = kv_get(cmd_res.data.key);
             if (value[0] == '\0') {
-                strncpy(response, "\n", BUFFER_SIZE);
+                strcpy(response, "NOT_FOUND\n");
             } else {
                 snprintf(response, BUFFER_SIZE, "%s\n", value);
             }


### PR DESCRIPTION
### 📄 Pull Request: Update README and Server Response for GET and DELETE

#### ✅ Summary

This PR includes two related updates to improve clarity and consistency:

1. **Updated README Documentation**
   - Modified the expected response for `GET` when the key does not exist (`NOT_FOUND\n` instead of `\n`)
   - Updated `DELETE` to note the correct success (`OK\n`) and failure (`NOT_FOUND\n`) responses

2. **Server Response Behavior**
   - Modified server logic to return NOT_FOUN (`NOT_FOUND\n`) for non-existent keys in `GET`, aligning behavior with DELETE operation

#### 📌 Motivation

These changes make the server protocol clearer for clients and ensure documentation matches the actual server behavior, reducing confusion and potential bugs.